### PR TITLE
MercadoPago and Emails.

### DIFF
--- a/templates/5ec1574d22999c4a5e8e0dc7/elements/Experimental/mercadoPagoOauth.tpl
+++ b/templates/5ec1574d22999c4a5e8e0dc7/elements/Experimental/mercadoPagoOauth.tpl
@@ -1,0 +1,48 @@
+/*
+path: mercadoPagoOauth.tpl
+completePath: elements/Experimental/mercadoPagoOauth.tpl
+unique_id: mercadoPagoOauth
+icon: ico-linkedin
+helpText: 'Oauth mechanism for Mercado Pago Payment Gateway'
+sourceType: javascript
+children: []
+options:
+  - name: clientID
+    display: Client ID
+    type: text
+    options: ''
+  - name: clientSecret
+    display: Client Secret
+    type: text
+    options: ''
+  - name: Code
+    display: Code
+    type: text
+  - name: RedirectURI
+    display: Redirect URI
+    type: text
+  - name: backendEndpoint
+    display: Endpoint for the backend
+    type: text
+    settings:
+      default: '/api/mercadopagooauth'
+      active: true
+settings:
+  - name: ServerRoute
+    value: |
+      const axios = require('axios')
+      app.post('{{ element.values.backendEndpoint | default('/api/mercadopagooauth') }}', (req, res, next) => {
+        axios.post('https://api.mercadopago.com/oauth/token', {
+          client_id: {{ element.values.clientID }},
+          client_secret: {{ element.values.clientSecret }},
+          grant_type: 'authorization_code',
+          code: {{ element.values.Code }},
+          redirect_uri: {{ element.values.RedirectURI }}
+        }).then(mpres => {
+          res.send(mpres.data)
+        }).catch(e => {
+          res.send(e)
+        })
+      })
+*/
+// Mercado Pago Oauth Implementation (endpoint: {{ element.values.backendEndpoint | default('/api/mercadopagooauth') }})

--- a/templates/5ec1574d22999c4a5e8e0dc7/elements/Fields/update.tpl
+++ b/templates/5ec1574d22999c4a5e8e0dc7/elements/Fields/update.tpl
@@ -3,4 +3,4 @@ path: update.tpl
 completePath: elements/Fields/update.tpl
 unique_id: 1a0ACFGq
 */
-if(data.{{ field.column_name | friendly }}) updatedData['{{ field.column_name | friendly }}'] = data.{{ field.column_name | friendly }}
+if(typeof data.{{ field.column_name | friendly }} !== 'undefined') updatedData['{{ field.column_name | friendly }}'] = data.{{ field.column_name | friendly }}

--- a/templates/5ec1574d22999c4a5e8e0dc7/elements/Interact/email.tpl
+++ b/templates/5ec1574d22999c4a5e8e0dc7/elements/Interact/email.tpl
@@ -10,6 +10,13 @@ options:
     display: Function Name
     type: text
     options: ''
+  - name: internalfunctionName
+    display: Internal Function Name
+    type: text
+    options: ''
+    advanced: true
+    settings:
+      default: "'InlineLink'"
   - name: service
     display: Email Sending service
     type: dropdown
@@ -129,7 +136,7 @@ import axios from 'axios'
 {% set functionName = 'sendEmail' %}
 {% endif %}
 const {{ functionName }} = (to, extra = {}) => {
-    const messageHtml = InlineLink({{ element.values.parameters }})
+    const messageHtml = {{ element.values.internalfunctionName|default('InlineLink') }}({{ element.values.parameters }})
     axios({
       method: "POST", 
       url:"{{ settings.apiURL | raw }}/api/sendEmail",

--- a/templates/5ec1574d22999c4a5e8e0dc7/elements/Interact/emailContent.tpl
+++ b/templates/5ec1574d22999c4a5e8e0dc7/elements/Interact/emailContent.tpl
@@ -6,12 +6,20 @@ icon: ico-field
 internalUse: true
 sourceType: javascript
 children: []
+options:
+  - name: internalfunctionName
+    display: Internal Function Name
+    type: text
+    options: ''
+    advanced: true
+    settings:
+      default: "'InlineLink'"
 */
 
 {% set bpr %}
 import _server from 'react-dom/server'
 
-function InlineLink(emailParameters = null) {
+function {{ element.values.internalfunctionName|default('InlineLink') }}(emailParameters = null) {
   var _server2 = _interopRequireDefault(_server)
   function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 


### PR DESCRIPTION
- Now Email component allows to define the internal function name, ending up in the possibility of sending multiple emails from the same page. (Advanced setting: "internalfunctioname"
- Empty strings passed to the controllers now save
- Added MercadoPagoOauth element.
- Improved MercadoPago element so the config items can be set from variables.